### PR TITLE
Added support for UPD/TCP communication to graphite

### DIFF
--- a/statsd.net/Backends/GraphiteBackend.cs
+++ b/statsd.net/Backends/GraphiteBackend.cs
@@ -36,8 +36,12 @@ namespace statsd.net.Backends
             _completionTask = new Task(() => { _isActive = false; });
             _senderBlock = new ActionBlock<GraphiteLine>((message) => SendLine(message), Utility.UnboundedExecution());
             _isActive = true;
+            
+            string _protocol = "UDP"; // Default protocol
+            if (configElement.Attribute("protocol") != null)
+                _protocol = configElement.Attribute("protocol").Value;
 
-            var config = new GraphiteConfiguration(configElement.Attribute("host").Value, configElement.ToInt("port"), configElement.Attribute("protocol").Value);
+            var config = new GraphiteConfiguration(configElement.Attribute("host").Value, configElement.ToInt("port"), _protocol);
             switch (config.GraphiteCommunicationProtocol.ToUpper())
             {
                 case "UDP":
@@ -116,7 +120,6 @@ namespace statsd.net.Backends
             _tcpClient.Connect(ipAddress, configuration.Port);
             _tcpStream = _tcpClient.GetStream();
         }
-
         public void SendLine(GraphiteLine line)
         {
             byte[] data = Encoding.ASCII.GetBytes((line + "\r\n"));

--- a/statsd.net/Configuration/BackendConfiguration.cs
+++ b/statsd.net/Configuration/BackendConfiguration.cs
@@ -6,76 +6,81 @@ using System.Threading.Tasks;
 
 namespace statsd.net.Configuration
 {
-  public class BackendConfiguration
-  {
-  }
-
-  public class SqlServerConfiguration : BackendConfiguration
-  {
-    public string ConnectionString { get; set; }
-    public int WriteBatchSize { get; set; }
-    public int Retries { get; private set; }
-
-    public SqlServerConfiguration(string connectionString, int writeBatchSize)
+    public class BackendConfiguration
     {
-      ConnectionString = connectionString;
-      WriteBatchSize = writeBatchSize;
-      Retries = 3;
     }
-  }
 
-  public class GraphiteConfiguration : BackendConfiguration
-  {
-    public string Host { get; set; }
-    public int Port { get; set; }
-
-    public GraphiteConfiguration(string host, int port)
+    public class SqlServerConfiguration : BackendConfiguration
     {
-      Host = host;
-      Port = port;
+        public string ConnectionString { get; set; }
+        public int WriteBatchSize { get; set; }
+        public int Retries { get; private set; }
+
+        public SqlServerConfiguration(string connectionString, int writeBatchSize)
+        {
+            ConnectionString = connectionString;
+            WriteBatchSize = writeBatchSize;
+            Retries = 3;
+        }
     }
-  }
 
-  public class ConsoleConfiguration : BackendConfiguration
-  {
-  }
-
-  public class LibratoBackendConfiguration : BackendConfiguration
-  {
-    public string Email { get; set; }
-    public string Token { get; set; }
-    public TimeSpan RetryDelay { get; set; }
-    public TimeSpan PostTimeout { get; set; }
-    public int MaxBatchSize { get; set; }
-    public bool CountersAsGauges { get; set; }
-    public int NumRetries { get; set; } 
-
-    public LibratoBackendConfiguration(string email, string token, TimeSpan retryDelay, int numRetries, TimeSpan postTimeout, int maxBatchSize, bool countersAsGauges)
+    public class GraphiteConfiguration : BackendConfiguration
     {
-      this.Email = email;
-      this.Token = token;
-      this.RetryDelay = retryDelay;
-      this.NumRetries = numRetries;
-      this.PostTimeout = postTimeout;
-      this.MaxBatchSize = maxBatchSize;
-      this.CountersAsGauges = countersAsGauges;
+        public string GraphiteCommunicationProtocol { get; set; }
+        public string Host { get; set; }
+        public int Port { get; set; }
+
+        public GraphiteConfiguration(string host, int port, string graphiteCommunicationProtocol)
+        {
+            GraphiteCommunicationProtocol = graphiteCommunicationProtocol;
+            Host = host;
+            Port = port;
+
+            if (graphiteCommunicationProtocol.ToUpper() != "UDP" && graphiteCommunicationProtocol.ToUpper() != "TCP")
+                throw new InvalidOperationException("configuration 'protocol' must be 'TCP' or 'UDP'");
+        }
     }
-  }
 
-  public class StatsdBackendConfiguration : BackendConfiguration
-  {
-    public string Host { get; set; }
-    public int Port { get; set; }
-    public TimeSpan FlushInterval { get; set; }
-    public bool EnableCompression { get; set; }
-
-    public StatsdBackendConfiguration(string host, int port, TimeSpan? flushInterval, bool enableCompression = true)
+    public class ConsoleConfiguration : BackendConfiguration
     {
-      Host = host;
-      Port = port;
-      FlushInterval = flushInterval ?? new TimeSpan(0, 0, 5);
-      EnableCompression = enableCompression;
     }
-  }
+
+    public class LibratoBackendConfiguration : BackendConfiguration
+    {
+        public string Email { get; set; }
+        public string Token { get; set; }
+        public TimeSpan RetryDelay { get; set; }
+        public TimeSpan PostTimeout { get; set; }
+        public int MaxBatchSize { get; set; }
+        public bool CountersAsGauges { get; set; }
+        public int NumRetries { get; set; }
+
+        public LibratoBackendConfiguration(string email, string token, TimeSpan retryDelay, int numRetries, TimeSpan postTimeout, int maxBatchSize, bool countersAsGauges)
+        {
+            this.Email = email;
+            this.Token = token;
+            this.RetryDelay = retryDelay;
+            this.NumRetries = numRetries;
+            this.PostTimeout = postTimeout;
+            this.MaxBatchSize = maxBatchSize;
+            this.CountersAsGauges = countersAsGauges;
+        }
+    }
+
+    public class StatsdBackendConfiguration : BackendConfiguration
+    {
+        public string Host { get; set; }
+        public int Port { get; set; }
+        public TimeSpan FlushInterval { get; set; }
+        public bool EnableCompression { get; set; }
+
+        public StatsdBackendConfiguration(string host, int port, TimeSpan? flushInterval, bool enableCompression = true)
+        {
+            Host = host;
+            Port = port;
+            FlushInterval = flushInterval ?? new TimeSpan(0, 0, 5);
+            EnableCompression = enableCompression;
+        }
+    }
 
 }

--- a/statsd.net/statsdnet.config
+++ b/statsd.net/statsdnet.config
@@ -15,6 +15,7 @@
     </aggregation>
     <backends>
         <statsdnet host="localhost" port="12001" flushInterval="5s" enableCompression="true"/>
+      <graphite host="aarlcubu01" port="2003" />
         <console />
     </backends>
 </statsdnet>

--- a/statsd.net/statsdnet.config.everything
+++ b/statsd.net/statsdnet.config.everything
@@ -27,7 +27,7 @@
                  countersAsGauges="true" />
         <sqlserver connectionString="server=localhost;database=metrics;uid=mmetricsuser;password=metricsuser"
                    writeBatchSize="500" />
-        <graphite host="localhost" port="2003" />
+        <graphite host="localhost" port="2003" protocol="tcp" />
         <statsdnet host="localhost" port="11002" flushInterval="5s"/>
     </backends>
 </statsdnet>


### PR DESCRIPTION
Graphite communication is now configurable to be either tcp or udp.
An attribute is added to the <graphite /> configuration tag that decides whether to use UDP og TCP when sending data to graphite.

Also includes a bug fix which adds a "\r\n" after each line sent to graphite in both UDP and TCP. The UDP part is untested though.
